### PR TITLE
fix: add qwen input prompts

### DIFF
--- a/app.py
+++ b/app.py
@@ -688,6 +688,9 @@ class InteractiveOAuthSession:
             # Codex / Claude 等
             "Enter choice",
             "Enter your choice",
+            # Qwen 补充
+            "email address",
+            "alias for qwen",
             # 通用
             "Please paste",
             "paste the URL",


### PR DESCRIPTION
> 添加 `Qwen` 账号，命令行输出显示要输入邮箱，但是没有输入框，翻看代码发现，需要增添 `Qwen` 的 `input_prompts `

<img width="1025" height="750" alt="image" src="https://github.com/user-attachments/assets/2142e302-5872-4d4b-aa90-a1ef94513cef" />

之后测试可以读取 `prompts`，弹出输入框，正常添加 `Qwen`