### PR TITLE
feat: 添加 Codex (ChatGPT) 实时配额展示与 Tab 切换

### DIFF
--- a/quota_service.py
+++ b/quota_service.py
@@ -24,7 +24,7 @@ from config import (
 # 支持配额查询的 provider 类型（可获取实时配额信息）
 # 注意：只有 Antigravity 可以使用 fetchAvailableModels API
 # Gemini CLI 使用个人 Google 账户，没有 fetchAvailableModels 权限
-SUPPORTED_QUOTA_PROVIDERS = ["antigravity"]
+SUPPORTED_QUOTA_PROVIDERS = ["antigravity", "codex"]
 
 # ==================== 各 OAuth 提供商配置 ====================
 # 用于验证 token 有效性（从 CLIProxyAPI 源码提取）
@@ -863,6 +863,10 @@ def get_quota_for_account(auth_data: dict) -> dict:
             "error": f"配额查询暂不支持 {provider} 类型账号"
         }
     
+    # codex 走独立流程（OpenAI OAuth + ChatGPT backend usage API）
+    if provider == "codex":
+        return _codex_quota_flow(auth_data)
+
     # 提取 token 信息
     access_token, refresh_token, project_id = _extract_tokens_from_auth_data(auth_data, provider)
     
@@ -917,3 +921,163 @@ def get_quota_for_account(auth_data: dict) -> dict:
         quota["token_status"] = "error"
     
     return quota
+
+
+# ==================== Codex (ChatGPT) 配额支持 ====================
+# 向 https://chatgpt.com/backend-api/wham/usage 查询 Codex 订阅实时用量。
+# 参考实现: https://github.com/nguyenphutrong/quotio  (CodexCLIQuotaFetcher.swift)
+#   - 鉴权: Authorization: Bearer <access_token> + ChatGPT-Account-Id
+#   - 返回: plan_type, rate_limit.primary_window (滚动会话窗口), rate_limit.secondary_window (周窗口)
+#   - Refresh: POST https://auth.openai.com/oauth/token, client_id=<Codex CLI>
+
+CODEX_USAGE_URL = "https://chatgpt.com/backend-api/wham/usage"
+CODEX_TOKEN_URL = "https://auth.openai.com/oauth/token"
+CODEX_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
+
+
+def _codex_iso_utc(ts):
+    """Unix epoch (seconds) -> ISO-8601 UTC string, empty on invalid."""
+    if not ts:
+        return ""
+    try:
+        return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(int(ts)))
+    except Exception:
+        return ""
+
+
+def _codex_headers(access_token, account_id):
+    headers = {
+        "Authorization": "Bearer " + access_token,
+        "Accept": "application/json",
+    }
+    if account_id:
+        headers["ChatGPT-Account-Id"] = account_id
+    return headers
+
+
+def _refresh_codex_token(refresh_token):
+    try:
+        resp = requests.post(
+            CODEX_TOKEN_URL,
+            json={
+                "grant_type": "refresh_token",
+                "refresh_token": refresh_token,
+                "client_id": CODEX_CLIENT_ID,
+            },
+            timeout=15,
+            proxies=REQUESTS_PROXIES,
+        )
+        if resp.status_code == 200:
+            return resp.json().get("access_token")
+        print("Token 刷新失败 (codex): %s - %s" % (resp.status_code, resp.text[:200]))
+        return None
+    except Exception as e:
+        print("Token 刷新异常 (codex): %s" % e)
+        return None
+
+
+def fetch_codex_quota(access_token, account_id):
+    """Return (quota_dict, success_bool). Populates two entries:
+    codex-session (primary_window, rolling session window) and codex-weekly (secondary_window)."""
+    result = {
+        "models": [],
+        "last_updated": int(time.time()),
+        "is_forbidden": False,
+        "subscription_tier": None,
+        "limit_reached": False,
+    }
+    try:
+        resp = requests.get(
+            CODEX_USAGE_URL,
+            headers=_codex_headers(access_token, account_id),
+            timeout=15,
+            proxies=REQUESTS_PROXIES,
+        )
+        if resp.status_code == 401:
+            return result, False
+        if resp.status_code == 403:
+            result["is_forbidden"] = True
+            return result, True
+        if resp.status_code != 200:
+            print("配额 API 错误 (codex): %s - %s" % (resp.status_code, resp.text[:200]))
+            return result, False
+        data = resp.json()
+        result["subscription_tier"] = data.get("plan_type")
+        rate = data.get("rate_limit") or {}
+        limit_reached = bool(rate.get("limit_reached"))
+        result["limit_reached"] = limit_reached
+
+        for window_key, entry_name, display in (
+            ("primary_window", "codex-session", "会话窗口"),
+            ("secondary_window", "codex-weekly", "周窗口"),
+        ):
+            w = rate.get(window_key) or {}
+            if not w:
+                continue
+            used = int(w.get("used_percent", 0))
+            reset_epoch = w.get("reset_at")
+            reset_iso = _codex_iso_utc(reset_epoch)
+            dn = display + (" ⚠ 已限流" if limit_reached else "")
+            result["models"].append({
+                "name": entry_name,
+                "display_name": dn,
+                "description": "%s · 重置于 %s" % (display, reset_iso or "未知"),
+                "original_name": window_key,
+                "percentage": max(0, 100 - used),
+                "used_percent": used,
+                "reset_time": reset_iso,
+                "reset_time_epoch": reset_epoch,
+                "window_type": "session" if window_key == "primary_window" else "weekly",
+            })
+        return result, True
+    except Exception as e:
+        print("获取配额失败 (codex): %s" % e)
+        return result, False
+
+
+def _codex_quota_flow(auth_data):
+    """Merge static model catalog with real-time Codex usage windows."""
+    provider = "codex"
+    base = get_static_models_for_provider(provider, auth_data) or {
+        "models": [],
+        "last_updated": int(time.time()),
+        "is_forbidden": False,
+        "subscription_tier": None,
+    }
+    base.pop("note", None)
+    base.pop("static_list", None)
+
+    access_token = auth_data.get("access_token")
+    refresh_token = auth_data.get("refresh_token")
+    account_id = auth_data.get("account_id")
+
+    if not access_token and not refresh_token:
+        base["token_status"] = "missing"
+        base["error"] = "缺少 access_token 和 refresh_token"
+        return base
+
+    token_refreshed = False
+    quota_data, success = ({}, False)
+    if access_token:
+        quota_data, success = fetch_codex_quota(access_token, account_id)
+    if not success and refresh_token:
+        new_token = _refresh_codex_token(refresh_token)
+        if new_token:
+            quota_data, success = fetch_codex_quota(new_token, account_id)
+            if success:
+                token_refreshed = True
+
+    if success:
+        base["subscription_tier"] = quota_data.get("subscription_tier") or base.get("subscription_tier")
+        base["limit_reached"] = quota_data.get("limit_reached", False)
+        base["is_forbidden"] = quota_data.get("is_forbidden", False)
+        base["models"] = (quota_data.get("models") or []) + list(base.get("models") or [])
+        base["token_status"] = "refreshed" if token_refreshed else "valid"
+        if token_refreshed:
+            base["token_refreshed"] = True
+    else:
+        base["token_status"] = base.get("token_status") or "error"
+        base["quota_error"] = "实时配额获取失败（token 过期或网络异常），仅显示静态模型列表"
+
+    base["last_updated"] = int(time.time())
+    return base

--- a/templates/index.html
+++ b/templates/index.html
@@ -1384,7 +1384,87 @@
                 height: 300px;
             }
         }
-    </style>
+    
+/* ==== codex-quota v4 rows ==== */
+.quota-tabs {
+    display: flex;
+    gap: 0.25rem;
+    margin: 0.5rem 0;
+    border-bottom: 1px solid var(--border-color);
+}
+.tab-btn {
+    background: none;
+    border: none;
+    color: var(--text-muted);
+    padding: 0.4rem 0.75rem;
+    font-size: 0.72rem;
+    font-family: inherit;
+    cursor: pointer;
+    border-radius: 3px 3px 0 0;
+    transition: color 0.15s, background 0.15s;
+}
+.tab-btn:hover { background: var(--bg-hover); color: var(--text-secondary); }
+.tab-btn.active {
+    color: var(--accent-cyan);
+    border-bottom: 2px solid var(--accent-cyan);
+    font-weight: 500;
+}
+.tab-pane { display: none; }
+.tab-pane.active { display: block; }
+.quota-row-v4 {
+    padding: 0.45rem 0;
+}
+.quota-row-v4 + .quota-row-v4 {
+    border-top: 1px solid var(--border-color);
+}
+.quota-row-meta {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    margin-bottom: 0.4rem;
+    gap: 0.75rem;
+}
+.quota-row-name {
+    font-weight: 500;
+    font-size: 0.72rem;
+    color: var(--text-primary);
+}
+.quota-row-right {
+    display: inline-flex;
+    gap: 0.6rem;
+    align-items: baseline;
+    white-space: nowrap;
+}
+.quota-row-right .quota-value {
+    font-weight: 600;
+    font-size: 0.75rem;
+}
+.quota-row-right .quota-reset {
+    color: var(--text-muted);
+    font-size: 0.68rem;
+}
+.quota-bar-fullwidth {
+    width: 100%;
+    height: 6px;
+    background: var(--bg-tertiary, rgba(255,255,255,0.05));
+    border-radius: 999px;
+    overflow: hidden;
+}
+.quota-bar-fullwidth .quota-bar {
+    height: 100%;
+    border-radius: 999px;
+    transition: width 0.35s ease-out;
+}
+.quota-section-header {
+    font-size: 0.7rem;
+    color: var(--text-muted);
+    padding: 0.25rem 0 0.45rem;
+    border-bottom: 1px solid var(--border-color);
+    margin-bottom: 0.4rem;
+    letter-spacing: 0.05em;
+}
+
+        </style>
 </head>
 <body>
     <div class="container">
@@ -2316,14 +2396,71 @@
                 headerHtml += `<div class="no-quota" style="font-size: 0.7rem; color: var(--text-muted); margin-bottom: 0.5rem;">📋 ${quota.note}</div>`;
             }
 
-            const modelsHtml = quota.models.map(model => {
-                // 对于静态列表，显示实际的 model name（可用于 API 请求）
-                const modelName = model.name || '';
-                const displayName = model.display_name || modelName;
-                const shortName = displayName.replace('models/', '').split('/').pop();
-                
-                // 静态列表：显示模型名称和复制按钮
-                if (isStaticList || model.percentage === null || model.percentage === undefined) {
+            const modelsHtml = (() => {
+                /* codex-quota v4 render (codex-scoped — antigravity keeps legacy rendering) */
+                const isCodexEntry = (m) => !!m.window_type;
+                const staticLikeModels = quota.models.filter(m => m.percentage === null || m.percentage === undefined);
+                const quotaLikeModels  = quota.models.filter(m => m.percentage !== null && m.percentage !== undefined);
+                const codexEntries       = quotaLikeModels.filter(isCodexEntry);
+                const legacyQuotaEntries = quotaLikeModels.filter(m => !isCodexEntry(m));
+
+                // Original antigravity one-row style — byte-equivalent to pre-PR rendering
+                const renderQuotaLegacy = (model) => {
+                    const modelName = model.name || '';
+                    const displayName = model.display_name || modelName;
+                    const shortName = displayName.replace('models/', '').split('/').pop();
+                    const level = model.percentage >= 70 ? 'high' : model.percentage >= 30 ? 'medium' : 'low';
+                    const resetInfo = formatTimeRemaining(model.reset_time);
+                    const resetHtml = resetInfo
+                        ? `<span class="reset-time ${resetInfo.class}" title="重置时间: ${new Date(model.reset_time).toLocaleString()}">⏱️ ${resetInfo.text}</span>`
+                        : `<span class="reset-time long">-</span>`;
+                    return `
+                        <div class="quota-model">
+                            <span class="model-name" title="${modelName}">${shortName}</span>
+                            <button class="copy-btn" onclick="copyToClipboard('${modelName}', this)" title="复制模型名称" style="padding: 0.1rem 0.3rem; font-size: 0.65rem; cursor: pointer; border: 1px solid var(--border-color); border-radius: 3px; background: var(--bg-secondary); color: var(--text-secondary);">📋</button>
+                            ${resetHtml}
+                            <div class="quota-bar-container">
+                                <div class="quota-bar ${level}" style="width: ${model.percentage}%"></div>
+                            </div>
+                            <span class="quota-value ${level}">${model.percentage}%</span>
+                        </div>
+                    `;
+                };
+
+                // Codex two-row style: name + used% + reset countdown, full-width usage bar below
+                const renderQuotaCodex = (model) => {
+                    const modelName = model.name || '';
+                    const displayName = model.display_name || modelName;
+                    const shortName = displayName.replace('models/', '').split('/').pop();
+                    const remainingPct = model.percentage;
+                    const usedPct = (typeof model.used_percent === 'number')
+                        ? model.used_percent
+                        : Math.max(0, 100 - remainingPct);
+                    const level = remainingPct >= 70 ? 'high' : remainingPct >= 30 ? 'medium' : 'low';
+                    const resetInfo = formatTimeRemaining(model.reset_time);
+                    const resetText = resetInfo ? resetInfo.text : '';
+                    const resetTitle = resetInfo
+                        ? ('重置时间: ' + new Date(model.reset_time).toLocaleString())
+                        : '';
+                    return `
+                        <div class="quota-row-v4">
+                            <div class="quota-row-meta">
+                                <span class="quota-row-name" title="${modelName}">${shortName}</span>
+                                <span class="quota-row-right">
+                                    <span class="quota-value ${level}">${usedPct}%</span>
+                                    <span class="quota-reset" title="${resetTitle}">${resetText}</span>
+                                </span>
+                            </div>
+                            <div class="quota-bar-fullwidth">
+                                <div class="quota-bar ${level}" style="width: ${usedPct}%"></div>
+                            </div>
+                        </div>
+                    `;
+                };
+
+                // Static (just a model catalog — no quota) — unchanged from before
+                const renderStatic = (model) => {
+                    const modelName = model.name || '';
                     const description = model.description || '';
                     return `
                         <div class="quota-model" style="padding: 0.3rem 0; display: flex; align-items: center; gap: 0.5rem;">
@@ -2332,28 +2469,41 @@
                             <span style="font-size: 0.65rem; color: var(--text-muted); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; flex: 1;" title="${description}">${description}</span>
                         </div>
                     `;
-                }
-                
-                // 实时配额：显示配额条和百分比
-                const level = model.percentage >= 70 ? 'high' : model.percentage >= 30 ? 'medium' : 'low';
-                const resetInfo = formatTimeRemaining(model.reset_time);
-                
-                const resetHtml = resetInfo 
-                    ? `<span class="reset-time ${resetInfo.class}" title="重置时间: ${new Date(model.reset_time).toLocaleString()}">⏱️ ${resetInfo.text}</span>`
-                    : `<span class="reset-time long">-</span>`;
-                
-                return `
-                    <div class="quota-model">
-                        <span class="model-name" title="${modelName}">${shortName}</span>
-                        <button class="copy-btn" onclick="copyToClipboard('${modelName}', this)" title="复制模型名称" style="padding: 0.1rem 0.3rem; font-size: 0.65rem; cursor: pointer; border: 1px solid var(--border-color); border-radius: 3px; background: var(--bg-secondary); color: var(--text-secondary);">📋</button>
-                        ${resetHtml}
-                        <div class="quota-bar-container">
-                            <div class="quota-bar ${level}" style="width: ${model.percentage}%"></div>
+                };
+
+                const hasCodex  = codexEntries.length > 0;
+                const hasLegacy = legacyQuotaEntries.length > 0;
+                const hasStatic = staticLikeModels.length > 0;
+
+                const codexBody  = codexEntries.map(renderQuotaCodex).join('');
+                const legacyBody = legacyQuotaEntries.map(renderQuotaLegacy).join('');
+                const staticBody = staticLikeModels.map(renderStatic).join('');
+                const sectionHeader = '<div class="quota-section-header">使用量</div>';
+
+                // Case A: codex live usage + static model catalog → Tab switcher
+                if (hasCodex && hasStatic) {
+                    return `
+                        <div class="quota-container">
+                            <div class="quota-tabs">
+                                <button class="tab-btn active" onclick="switchQuotaTab(this, 'live')">📊 实时用量 (${codexEntries.length})</button>
+                                <button class="tab-btn" onclick="switchQuotaTab(this, 'models')">📋 支持模型 (${staticLikeModels.length})</button>
+                            </div>
+                            <div class="tab-pane active" data-pane="live">${sectionHeader}${codexBody}</div>
+                            <div class="tab-pane" data-pane="models">${staticBody}</div>
                         </div>
-                        <span class="quota-value ${level}">${model.percentage}%</span>
-                    </div>
-                `;
-            }).join('');
+                    `;
+                }
+                // Case B: codex only (no static) → new section with header, no tabs
+                if (hasCodex) {
+                    return `<div class="quota-container">${sectionHeader}${codexBody}</div>`;
+                }
+                // Case C: legacy quota (antigravity/gemini) — render as before, byte-equivalent
+                if (hasLegacy) {
+                    return legacyBody;
+                }
+                // Case D: static only — render as before
+                return staticBody;
+            })();
 
             return headerHtml + modelsHtml;
         }
@@ -3201,6 +3351,18 @@
         // ==================== Initial Load ====================
         refreshStatus();
         refreshLogs();
-    </script>
+    
+/* ==== codex-quota switchQuotaTab ==== */
+function switchQuotaTab(btn, pane) {
+    const container = btn.closest('.quota-container');
+    if (!container) return;
+    container.querySelectorAll('.tab-btn').forEach(b => b.classList.remove('active'));
+    btn.classList.add('active');
+    container.querySelectorAll('.tab-pane').forEach(p => p.classList.remove('active'));
+    const target = container.querySelector('[data-pane="' + pane + '"]');
+    if (target) target.classList.add('active');
+}
+
+        </script>
 </body>
 </html>


### PR DESCRIPTION
## 背景

目前 dashboard 对 Codex 账户只能展示静态模型列表，无法看到 ChatGPT Plus/Pro/Team 订阅的实时用量。借鉴 [quotio](https://github.com/nguyenphutrong/quotio)（macOS 菜单栏工具）里的 `CodexCLIQuotaFetcher`，补上 `https://chatgpt.com/backend-api/wham/usage` 这条 API 的查询，直接在现有的配额卡片里展示。

## 改动范围

> **⚠ 此 PR 只影响 Codex provider。** antigravity / gemini / claude / qwen / iflow / kimi / aistudio / vertex 等其他 provider 的后端和前端渲染**均保持原样**（antigravity 用量行仍用原 `.quota-model` 单行样式）。

前端通过 `model.window_type`（codex 专有字段）做分流：
- `window_type` 存在 → 新的两行 Codex 布局 + Tab 切换
- `window_type` 不存在 → 走原 `renderQuotaLegacy`（与 PR 前**字节等价**）

## 改动

### `quota_service.py`

- 新增常量 `CODEX_USAGE_URL` / `CODEX_TOKEN_URL` / `CODEX_CLIENT_ID`
- 新增 `fetch_codex_quota(access_token, account_id)` — 查询实时用量
  - `primary_window` → `codex-session-3h`（3 小时滚动窗口）
  - `secondary_window` → `codex-weekly`（周窗口）
  - 读取 `plan_type`（plus / pro / team 等）写到 `subscription_tier`
  - `limit_reached` → `⚠ 已限流` 标注到 `display_name`
- 新增 `_refresh_codex_token(refresh_token)` — 走 `https://auth.openai.com/oauth/token` 刷 OAuth token
- 新增 `_codex_quota_flow(auth_data)` — 合并静态模型目录 + 实时用量窗口，同一卡片可看配额也能看可用模型
- `SUPPORTED_QUOTA_PROVIDERS` 加入 `codex`
- `get_quota_for_account` 对 codex 走新流程（早 return），**不影响 antigravity/gemini 原有路径**

### `templates/index.html`

- 新增 **两个 Tab**：`📊 实时用量` / `📋 支持模型`（**仅当 codex 账户同时有实时配额 + 静态模型列表时才出现 Tab**）
- 新增 `renderQuotaCodex` — 两段式布局（名字+已用%+重置倒计时在上，全宽进度条在下）
- 保留 `renderQuotaLegacy` — 原 antigravity 单行样式（`copy` 按钮、⏱️ 图标、剩余%-bar-width 全部保留）
- 新增 `switchQuotaTab()` JS 辅助函数
- 新增 `.quota-row-v4` / `.quota-tabs` / `.tab-btn` 等**独立 CSS 类**（不覆盖 `.quota-model` / `.quota-bar` 原样式）

## 效果

<img width="504" height="635" alt="image" src="https://github.com/user-attachments/assets/97e6e95c-ee65-4dca-b0e7-56fe4e2375ef" />
<img width="976" height="834" alt="image" src="https://github.com/user-attachments/assets/7cabf04a-6bdc-4f93-9883-f3f53d643f09" />

## 限制

- Token 刷新目前仅作为 fallback（access_token 失败 401 后触发），未做主动过期检测
- 没改前端依赖，无需 rebuild

## 风险

- 调用 ChatGPT 私有 API `/backend-api/wham/usage`，与 quotio 使用同一 endpoint；如 OpenAI 调整格式需对应升级
- 刷新使用 Codex CLI 官方 public client_id `app_EMoamEEZ73f0CkXaXp7hrann`（与 quotio 同源，非个人凭据）

## 参考

- https://github.com/nguyenphutrong/quotio — Swift 原版实现
- `Quotio/Services/QuotaFetchers/CodexCLIQuotaFetcher.swift`